### PR TITLE
Add support to exclude packages/paths

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Related issues
+
+Fixes: <!-- One or more issue numbers. THIS SHOULD ONLY BE ONE ISSUE UNLESS THERE ARE DUPLICATES. -->
+
+## Description
+
+<!-- Please include a summary of the change. Please also include relevant motivation and context. -->
+
+## Checklist
+<!-- Before removing WIP label, check all boxes below. -->
+
+- [ ] I have left self-review comments to help other reviewers.
+- [ ] My PR is as small as possible and focused on a single task.
+- [ ] I have considered and implemented security best practices.
+- [ ] If tagging multiple reviewers, I have made specific asks.
+
+## Manual testing
+<!-- Before requesting reviews, check all boxes below. -->
+
+- [ ] <!-- List all the verification steps you'll perform here (at least one) -->

--- a/.github/workflows/assign-wip.yaml
+++ b/.github/workflows/assign-wip.yaml
@@ -1,0 +1,15 @@
+name: Add WIP Label to new PRs
+on:
+  pull_request_target:
+
+jobs:
+  add-label:
+    name: Add Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Bob-MYMC/add-labels@master
+        with:
+          labels: |
+            WIP
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,19 @@ FROM golang:latest
 
 ENV GO111MODULE=on
 
+# installing go packages with `go get` is going to be removed soon, so we `go install <package>@latest` for each instead, since `go install` doesn't
+# support multiple modules at once.
 RUN apt-get update && \
 	apt-get -y install jq && \
-	go get -u \
-		github.com/kisielk/errcheck \
-		golang.org/x/tools/cmd/goimports \
-		golang.org/x/lint/golint \
-		github.com/securego/gosec/cmd/gosec \
-		golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow \
-		honnef.co/go/tools/cmd/staticcheck
+	go install github.com/kisielk/errcheck@latest && \
+	go install golang.org/x/tools/cmd/goimports@latest && \
+	go install golang.org/x/lint/golint@latest && \
+	go install github.com/securego/gosec/cmd/gosec@latest && \
+	go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest && \
+	go install honnef.co/go/tools/cmd/staticcheck@latest && \
+	go install github.com/client9/misspell/cmd/misspell@latest && \
+	go install github.com/gordonklaus/ineffassign@latest && \
+	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ resources that Go can't/won't clean automatically. Simply set this to `true` to 
 The highest cyclomatic complexity to consider "ok" with the `cyclo` check. The default of 15 was chosen to match [Go Report
 Card](https://goreportcard.com/)'s grading value.
 
+### exclude (default: empty)
+A list (comma-separated) of packages/paths to exclude from checks that support excludes. At the moment, that's just `cyclo` and `errcheck`. We're
+exploring mechanisms for extending this to the other checks, too, but this will take some time to implement correctly.
+
 ### go-private-mod-username (default: empty)
 Login username for getting Go dependencies from private repos.
 

--- a/README.md
+++ b/README.md
@@ -1,44 +1,125 @@
 # Golang GitHub Actions
+Static code analysis checker for golang. If there's an error, it also sends comments back to the current pull request (or the current commit if the
+action's trigger wasn't a PR).
 
-static code analysis checker for golang. comments back on error to pull request.
+## Inputs
+A quick summary of the values you can give using `with`.
 
-## Runs
+### run (required)
+Execute comma-separated command(s). Valid options are any combination of `cyclo`, `errcheck`, `fmt`, `imports`, `ineffassign`, `lint`, `misspell`,
+`sec`, `shadow`, `staticcheck`, and `vet`, or the shorthand option `all`. See below for more details.
 
-### Fmt
-Runs `gofmt` and comments back on error.
+### directory (default: `.`)
+The directory to run the check(s) within. Useful for monorepos to check subdirectories rather than the entire repository.
+
+### comment (default: `true`)
+If set to `true` (the default), a comment will be sent to the PR/commit that triggered the action whenever a check fails. If you prefer to check the
+action logs, go ahead and turn this off.
+
+### token (default: empty)
+GitHub token (use `${{ secrets.GITHUB_TOKEN }}` for this, since it's automatically provided for you). This is required when `comment` is `true` (so,
+by default).
+
+### flags (default: empty)
+Add flags to pass to the check commands. **Be careful with this option if you're running multiple checks, since these flags will be passed to _every_
+check command.**
+
+### ignore-defer (default: `false`)
+By default, `errcheck` marks `defer` statements as problems. Of course, sometimes (usually?) you _want_ to `defer` certain logic, say for cleaning up
+resources that Go can't/won't clean automatically. Simply set this to `true` to ignore this error as a false positive.
+
+### max-complexity (default: `15`)
+The highest cyclomatic complexity to consider "ok" with the `cyclo` check. The default of 15 was chosen to match [Go Report
+Card](https://goreportcard.com/)'s grading value.
+
+### go-private-mod-username (default: empty)
+Login username for getting Go dependencies from private repos.
+
+### go-private-mod-password (default: empty)
+Password (or GitHub personal access token) for getting Go dependencies from private repos.
+
+### go-private-mod-org-path (default: empty)
+Private organization URL, eg. `github.com/my-org`, for getting Go dependencies from private repos.
+
+
+## More info about checks you can `run`
+
+### all
+Runs all the checks below in a semi-sane order. Internally, it just translates `all` to
+`misspell,fmt,vet,cyclo,imports,ineffassign,errcheck,sec,shadow,staticcheck,lint` - you can take advantage of this to leave certain checks out, or to
+change the order they run in. (I personally recommend dropping `lint`, since it's deprecated anyway...)
+
+Keep in mind that this doesn't fail-fast, so all the listed checks will be run even if one fails.
+
+Also keep in mind that you'll get one comment on your PR/commit for each check that fails, which can add up a bit if your code fails more than one
+consistently. This is currently considered a feature rather than a bug, though, for two reasons. First, it's extra incentive to correct the code!
+Second, GitHub enforces a comment-length limit that might prevent your combined error comment from posting, which gets frustrating quickly when you're
+trying to avoid scouring logs.
+
+### fmt
+Runs `gofmt` (not to be confused with `go fmt`, which has fewer options) (and comments back on error).
+
 <img src="./assets/fmt.png" alt="Fmt Action" width="80%" />
 
-### Vet
-Runs `go vet` and comments back on error.
+### vet
+Runs `go vet` (and comments back on error).
 
-### Shadow
-Runs `go vet --vettool=/go/bin/shadow` and comments back on error.  
-Use: [golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow](https://godoc.org/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow)
+### shadow
+Runs `go vet --vettool=$(which shadow)` (and comments back on error).  
 
-### Imports
-Runs `goimports` and comments back on error.  
-Use: [golang.org/x/tools/cmd/goimports](https://godoc.org/golang.org/x/tools/cmd/goimports)
+See [golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow](https://godoc.org/golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow) for more info.
+
+### imports
+Runs `goimports` (and comments back on error).  
+
+See [golang.org/x/tools/cmd/goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) for more info.
+
 <img src="./assets/imports.png" alt="Imports Action" width="80%" />
 
-### Lint
-Runs `golint` and comments back on error.  
-Use: [golang.org/x/lint/golint](https://github.com/golang/lint)
+### lint
+**DEPRECATED** 
+
+Runs `golint` (and comments back on error).
+
+See [golang.org/x/lint/golint](https://github.com/golang/lint) for more info.
+
 <img src="./assets/lint.png" alt="Lint Action" width="80%" />
 
-### Staticcheck
-Runs `staticcheck` and comments back on error.  
-Use: [honnef.co/go/tools/cmd/staticcheck](https://staticcheck.io/)
+### staticcheck
+Runs `staticcheck` (and comments back on error).  
+
+See [honnef.co/go/tools/cmd/staticcheck](https://staticcheck.io/) for more info.
+
 <img src="./assets/staticcheck.png" alt="Staticcheck Action" width="80%" />
 
-### Errcheck
-Runs `errcheck` and comments back on error.  
-Use: [github.com/kisielk/errcheck](https://github.com/kisielk/errcheck)
+### errcheck
+Runs `errcheck` (and comments back on error).  
+
+See [github.com/kisielk/errcheck](https://github.com/kisielk/errcheck) for more info.
+
 <img src="./assets/errcheck.png" alt="Errcheck Action" width="80%" />
 
-### Sec
-Runs `gosec` and comments back on error.  
-Use: [github.com/securego/gosec/cmd/gosec](https://github.com/securego/gosec)
+### sec
+Runs `gosec` (and comments back on error).  
+
+See [github.com/securego/gosec/cmd/gosec](https://github.com/securego/gosec) for more info.
+
 <img src="./assets/sec.png" alt="Sec Action" width="80%" />
+
+### ineffassign
+Runs `ineffassign` (and comments back on error).
+
+See [github.com/gordonklaus/ineffassign](https://github.com/gordonklaus/ineffassign) for more info.
+
+### misspell
+Runs `misspell` (and comments back on error).
+
+See [github.com/client9/misspell/cmd/misspell](https://github.com/client9/misspell) for more info.
+
+### cyclo
+Runs `gocyclo` (and comments back on error).
+
+See [github.com/fzipp/gocyclo/cmd/gocyclo](https://github.com/fzipp/gocyclo) for more info.
 
 ## Sample Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: "the highest cyclomatic complexity to ignore with gocyclo"
     default: "15"
     required: false
+  exclude:
+    description: "paths or packages to exclude from checks. Not well supported yet."
+    default: ""
+    required: false
   go-private-mod-username:
     description: "login username for go dependencies from private repos"
     default: ""
@@ -52,6 +56,7 @@ runs:
     - ${{ inputs.flags }}
     - ${{ inputs.ignore-defer }}
     - ${{ inputs.max-complexity }}
+    - ${{ inputs.exclude }}
     - ${{ inputs.go-private-mod-username }}
     - ${{ inputs.go-private-mod-password }}
     - ${{ inputs.go-private-mod-org-path }}

--- a/action.yml
+++ b/action.yml
@@ -1,20 +1,20 @@
-name: "static analysis checker"
-description: "static code analysis checker for golang"
-author: "grandcolline"
+name: "Golang Static Analysis Checker"
+description: "A configurable static code analysis checker for Golang"
+author: "danhunsaker"
 inputs:
   run:
-    description: "excute command. [errcheck/fmt/imports/lint/sec/shadow/staticcheck/vet]"
+    description: "execute comma-separated command(s). [errcheck/fmt/imports/ineffassign/lint/misspell/sec/shadow/staticcheck/vet]"
     required: true
   directory:
-    description: "action wroking directory."
+    description: "action working directory."
     default: "."
     required: false
   comment:
-    description: "send comment to PR if true."
-    default: true
+    description: "send comment to PR (or commit) if true."
+    default: "true"
     required: false
   token:
-    description: "github token. this is require when comment is true."
+    description: "GitHub token. this is required when comment is true."
     default: ""
     required: false
   flags:
@@ -23,17 +23,21 @@ inputs:
     required: false
   ignore-defer:
     description: "if this is true, do not detect 'defer' with error. This is only valid when run is errcheck."
-    default: false
+    default: "false"
     required: false
-  go-mod-gh-username:
-    description: "github username for go dependencies from private repos. Must match the account token generated under"
+  max-complexity:
+    description: "the highest cyclomatic complexity to ignore with gocyclo"
+    default: "15"
+    required: false
+  go-private-mod-username:
+    description: "login username for go dependencies from private repos"
     default: ""
     required: false
-  go-mod-gh-token:
-    description: "github personal access token for go dependencies from private repos. Must match username account"
+  go-private-mod-password:
+    description: "password or GitHub personal access token for go dependencies from private repos"
     default: ""
     required: false
-  go-mod-goprivate:
+  go-private-mod-org-path:
     description: "git private organization url. eg. github.com/my-org"
     default: ""
     required: false
@@ -47,9 +51,10 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.flags }}
     - ${{ inputs.ignore-defer }}
-    - ${{ inputs.go-mod-gh-username }}
-    - ${{ inputs.go-mod-gh-token }}
-    - ${{ inputs.go-mod-goprivate }}
+    - ${{ inputs.max-complexity }}
+    - ${{ inputs.go-private-mod-username }}
+    - ${{ inputs.go-private-mod-password }}
+    - ${{ inputs.go-private-mod-org-path }}
 branding:
   icon: "alert-triangle"
   color: "yellow"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,17 +4,20 @@ set -e
 # ------------------------
 #  Environments
 # ------------------------
-RUN=$1
-WORKING_DIR=$2
-SEND_COMMNET=$3
-GITHUB_TOKEN=$4
-FLAGS=$5
-IGNORE_DEFER_ERR=$6
-GO_MOD_GH_USERNAME=$7
-GO_MOD_GH_TOKEN=$8
-GO_MOD_GOPRIVATE=$9
+self=${0}
+RUN=${1}
+WORKING_DIR=${2}
+SEND_COMMENT=${3}
+GITHUB_TOKEN=${4}
+FLAGS=${5}
+IGNORE_DEFER_ERR=${6}
+MAX_COMPLEXITY=${7}
+GO_PRIVATE_MOD_USERNAME=${8}
+GO_PRIVATE_MOD_PASSWORD=${9}
+GO_PRIVATE_MOD_ORG_PATH=${10}
 
-MODULE_NAME=`echo $WORKING_DIR | sed "s#./##g"`
+SUBMODULE_NAME=$(echo ${WORKING_DIR} | sed 's#\./##g')
+MODULE_NAME=$(echo "github.com/${GITHUB_REPOSITORY}/${SUBMODULE_NAME}" | sed 's#/\.?$##')
 
 COMMENT=""
 SUCCESS=0
@@ -27,46 +30,73 @@ SUCCESS=0
 # this function use ${GITHUB_TOKEN}, ${COMMENT} and ${GITHUB_EVENT_PATH}
 send_comment() {
 	PAYLOAD=$(echo '{}' | jq --arg body "${COMMENT}" '.body = $body')
-	COMMENTS_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+	if [ "${GITHUB_EVENT_NAME}" == "pull_request" ]; then
+		COMMENTS_URL=$(cat ${GITHUB_EVENT_PATH} | jq -r .pull_request.comments_url)
+	else
+		SHA=$(cat ${GITHUB_EVENT_PATH} | jq -r .commits[0].id)
+		COMMENTS_URL=$(echo "$(cat ${GITHUB_EVENT_PATH} | jq -r .repository.commits_url)/comments" | sed -n 's#\{/sha\}#/'${SHA}'#p')
+	fi
 	curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data "${PAYLOAD}" "${COMMENTS_URL}" > /dev/null
 }
 
 setup_private_repo_access() {
 	# setup access to go private modules via .netrc file
-	if [ "${GO_MOD_GOPRIVATE}" != "" ]; then
+	if [ "${GO_PRIVATE_MOD_ORG_PATH}" != "" ]; then
 		cat << EOF > .netrc
-machine github.com
-  login $GO_MOD_GH_USERNAME
-  password $GO_MOD_GH_TOKEN
+machine $(echo ${GO_PRIVATE_MOD_ORG_PATH} | sed 's#/.*##')
+  login ${GO_PRIVATE_MOD_USERNAME}
+  password ${GO_PRIVATE_MOD_PASSWORD}
 EOF
 
-		git config --global "url.https://$GO_MOD_GH_USERNAME:$GO_MOD_GH_TOKEN@github.com/9count/.insteadOf" https://github.com/9count/
+		git config --global "url.https://${GO_PRIVATE_MOD_USERNAME}:${GO_PRIVATE_MOD_PASSWORD}@${GO_PRIVATE_MOD_ORG_PATH}/.insteadOf" https://${GO_PRIVATE_MOD_ORG_PATH}/
 
-		go env -w GOPRIVATE="${GO_MOD_GOPRIVATE}"
+		go env -w GOPRIVATE="${GO_PRIVATE_MOD_ORG_PATH}"
 		# check result status and report back
 		if [ $? != 0 ]; then
-				printf "\t\033[31mSetup go private repos for: ${GO_MOD_GOPRIVATE} \033[0m \033[0;30m\033[41mFAILURE!\033[0m\n"
+				printf "\t\033[31mSetup go private repos for: ${GO_PRIVATE_MOD_ORG_PATH} \033[0m \033[0;30m\033[41mFAILURE!\033[0m\n"
 		else
-				printf "\t\033[32mSetup go private repos for: ${GO_MOD_GOPRIVATE} \033[0m \033[0;30m\033[42mpass\033[0m\n"
+				printf "\t\033[32mSetup go private repos for: ${GO_PRIVATE_MOD_ORG_PATH} \033[0m \033[0;30m\033[42mpass\033[0m\n"
 		fi
 	fi
 }
 
 # mod_download is getting go modules using go.mod.
 mod_download() {
-	if [ ! -e go.mod ]; then go mod init; fi
+	if [ ! -e go.mod ]; then go mod init ${MODULE_NAME}; fi
 	go mod download
 	if [ $? -ne 0 ]; then exit 1; fi
 }
 
-# check_errcheck is excute "errcheck" and generate ${COMMENT} and ${SUCCESS}
+# check_cyclo executes gocyclo and generate ${COMMENT} and ${SUCCESS}
+check_cyclo() {
+	set +e
+	OUTPUT=$(sh -c "gocyclo -over ${MAX_COMPLEXITY} -avg -total ${FLAGS} . $*" 2>&1)
+	SUCCESS=$?
+
+	set -e
+	if [ ${SUCCESS} -eq 0 ]; then
+		return
+	fi
+
+	COMMENT="## ⚠ gocyclo failed (${SUBMODULE_NAME})
+$(echo "${OUTPUT}" | head -n-2 | wc -l) function(s) exceeding a complexity of ${MAX_COMPLEXITY}
+<details><summary>Show Detail</summary>
+
+\`\`\`
+${OUTPUT}
+\`\`\`
+</details>
+"
+}
+
+# check_errcheck executes "errcheck" and generate ${COMMENT} and ${SUCCESS}
 check_errcheck() {
 	if [ "${IGNORE_DEFER_ERR}" = "true" ]; then
 		IGNORE_COMMAND="| grep -v defer"
 	fi
 
 	set +e
-	OUTPUT=$(sh -c "errcheck ${FLAGS} ./... ${IGNORE_COMMAND} $*" 2>&1)
+	OUTPUT=$(sh -c "errcheck ${FLAGS} ./... $* ${IGNORE_COMMAND}" 2>&1)
 	test -z "${OUTPUT}"
 	SUCCESS=$?
 
@@ -75,16 +105,14 @@ check_errcheck() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ errcheck failed ($MODULE_NAME)
+	COMMENT="## ⚠ errcheck failed (${SUBMODULE_NAME})
 \`\`\`
 ${OUTPUT}
 \`\`\`
 "
-	fi
 }
 
-# check_fmt is excute "go fmt" and generate ${COMMENT} and ${SUCCESS}
+# check_fmt executes "go fmt" and generate ${COMMENT} and ${SUCCESS}
 check_fmt() {
 	set +e
 	UNFMT_FILES=$(sh -c "gofmt -l -s . $*" 2>&1)
@@ -96,11 +124,10 @@ check_fmt() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		FMT_OUTPUT=""
-		for file in ${UNFMT_FILES}; do
-			FILE_DIFF=$(gofmt -d -e "${file}" | sed -n '/@@.*/,//{/@@.*/d;p}')
-			FMT_OUTPUT="${FMT_OUTPUT}
+	FMT_OUTPUT=""
+	for file in ${UNFMT_FILES}; do
+		FILE_DIFF=$(gofmt -d -e "${file}" | sed -n '/@@.*/,//{/@@.*/d;p}')
+		FMT_OUTPUT="${FMT_OUTPUT}
 <details><summary><code>${file}</code></summary>
 
 \`\`\`diff
@@ -109,14 +136,13 @@ ${FILE_DIFF}
 </details>
 
 "
-		done
-		COMMENT="## ⚠ gofmt failed ($MODULE_NAME)
+	done
+	COMMENT="## ⚠ gofmt failed (${SUBMODULE_NAME})
 ${FMT_OUTPUT}
 "
-	fi
 }
 
-# check_imports is excute go imports and generate ${COMMENT} and ${SUCCESS}
+# check_imports executes go imports and generate ${COMMENT} and ${SUCCESS}
 check_imports() {
 	set +e
 	UNFMT_FILES=$(sh -c "goimports -l . $*" 2>&1)
@@ -128,11 +154,10 @@ check_imports() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		FMT_OUTPUT=""
-		for file in ${UNFMT_FILES}; do
-			FILE_DIFF=$(goimports -d -e "${file}" | sed -n '/@@.*/,//{/@@.*/d;p}')
-			FMT_OUTPUT="${FMT_OUTPUT}
+	FMT_OUTPUT=""
+	for file in ${UNFMT_FILES}; do
+		FILE_DIFF=$(goimports -d -e "${file}" | sed -n '/@@.*/,//{/@@.*/d;p}')
+		FMT_OUTPUT="${FMT_OUTPUT}
 <details><summary><code>${file}</code></summary>
 
 \`\`\`diff
@@ -141,15 +166,31 @@ ${FILE_DIFF}
 </details>
 
 "
-		done
-		COMMENT="## ⚠ goimports failed ($MODULE_NAME)
+	done
+	COMMENT="## ⚠ goimports failed (${SUBMODULE_NAME})
 ${FMT_OUTPUT}
 "
-	fi
-
 }
 
-# check_lint is excute golint and generate ${COMMENT} and ${SUCCESS}
+# check_ineffassign executes "ineffassign" and generate ${COMMENT} and ${SUCCESS}
+check_ineffassign() {
+	set +e
+	OUTPUT=$(sh -c "ineffassign ./... $*" 2>&1)
+	SUCCESS=$?
+
+	set -e
+	if [ ${SUCCESS} -eq 0 ]; then
+		return
+	fi
+
+	COMMENT="## ⚠ ineffassign failed
+\`\`\`
+${OUTPUT}
+\`\`\`
+"
+}
+
+# check_lint executes golint and generate ${COMMENT} and ${SUCCESS}
 check_lint() {
 	set +e
 	OUTPUT=$(sh -c "golint -set_exit_status ./... $*" 2>&1)
@@ -160,8 +201,7 @@ check_lint() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ golint failed ($MODULE_NAME)
+	COMMENT="## ⚠ golint failed (${SUBMODULE_NAME})
 $(echo "${OUTPUT}" | awk 'END{print}')
 <details><summary>Show Detail</summary>
 
@@ -170,13 +210,12 @@ $(echo "${OUTPUT}" | sed -e '$d')
 \`\`\`
 </details>
 "
-	fi
 }
 
-# check_sec is excute gosec and generate ${COMMENT} and ${SUCCESS}
-check_sec() {
+# check_misspelling executes "misspell" and generate ${COMMENT} and ${SUCCESS}
+check_misspelling() {
 	set +e
-	gosec -out result.txt ${FLAGS} ./...
+	OUTPUT=$(sh -c "misspell ${FLAGS} -error . $*" 2>&1)
 	SUCCESS=$?
 
 	set -e
@@ -184,8 +223,25 @@ check_sec() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ gosec failed ($MODULE_NAME)
+	COMMENT="## ⚠ misspell failed
+\`\`\`
+${OUTPUT}
+\`\`\`
+"
+}
+
+# check_sec executes gosec and generate ${COMMENT} and ${SUCCESS}
+check_sec() {
+	set +e
+	gosec -quiet ${FLAGS} ./... > result.txt 2>&1
+	SUCCESS=$?
+
+	set -e
+	if [ ${SUCCESS} -eq 0 ]; then
+		return
+	fi
+
+	COMMENT="## ⚠ gosec failed (${SUBMODULE_NAME})
 \`\`\`
 $(tail -n 6 result.txt)
 \`\`\`
@@ -198,13 +254,14 @@ $(cat result.txt)
 
 </details>
 "
-	fi
+
+	rm result.txt
 }
 
-# check_shadow is excute "go vet -vettool=/go/bin/shadow" and generate ${COMMENT} and ${SUCCESS}
+# check_shadow executes "go vet -vettool=/go/bin/shadow" and generate ${COMMENT} and ${SUCCESS}
 check_shadow() {
 	set +e
-	OUTPUT=$(sh -c "go vet -vettool=/go/bin/shadow ${FLAGS} ./... $*" 2>&1)
+	OUTPUT=$(sh -c "go vet -vettool=$(which shadow) ${FLAGS} ./... $*" 2>&1)
 	SUCCESS=$?
 
 	set -e
@@ -212,16 +269,14 @@ check_shadow() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ shadow failed ($MODULE_NAME)
+	COMMENT="## ⚠ shadow failed (${SUBMODULE_NAME})
 \`\`\`
 ${OUTPUT}
 \`\`\`
 "
-	fi
 }
 
-# check_staticcheck is excute "staticcheck" and generate ${COMMENT} and ${SUCCESS}
+# check_staticcheck executes "staticcheck" and generate ${COMMENT} and ${SUCCESS}
 check_staticcheck() {
 	set +e
 	OUTPUT=$(sh -c "staticcheck ${FLAGS} ./... $*" 2>&1)
@@ -232,18 +287,16 @@ check_staticcheck() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ staticcheck failed ($MODULE_NAME)
+	COMMENT="## ⚠ staticcheck failed (${SUBMODULE_NAME})
 \`\`\`
 ${OUTPUT}
 \`\`\`
 
 [Checks Document](https://staticcheck.io/docs/checks)
 "
-	fi
 }
 
-# check_vet is excute "go vet" and generate ${COMMENT} and ${SUCCESS}
+# check_vet executes "go vet" and generate ${COMMENT} and ${SUCCESS}
 check_vet() {
 	set +e
 	OUTPUT=$(sh -c "go vet ${FLAGS} ./... $*" 2>&1)
@@ -254,13 +307,11 @@ check_vet() {
 		return
 	fi
 
-	if [ "${SEND_COMMNET}" = "true" ]; then
-		COMMENT="## ⚠ vet failed ($MODULE_NAME)
+	COMMENT="## ⚠ vet failed (${SUBMODULE_NAME})
 \`\`\`
 ${OUTPUT}
 \`\`\`
 "
-	fi
 }
 
 
@@ -271,7 +322,14 @@ cd ${GITHUB_WORKSPACE}/${WORKING_DIR}
 
 setup_private_repo_access
 
+if [ ${RUN} = "all" ]; then
+	RUN="misspell,fmt,vet,cyclo,imports,ineffassign,errcheck,sec,shadow,staticcheck,lint"
+fi
+
 case ${RUN} in
+	"cyclo" )
+		check_cyclo
+		;;
 	"errcheck" )
 		mod_download
 		check_errcheck
@@ -282,8 +340,16 @@ case ${RUN} in
 	"imports" )
 		check_imports
 		;;
+	"ineffassign" )
+		mod_download
+		check_ineffassign
+		;;
 	"lint" )
 		check_lint
+		;;
+	"misspell" )
+		mod_download
+		check_misspelling
 		;;
 	"sec" )
 		mod_download
@@ -301,19 +367,34 @@ case ${RUN} in
 		mod_download
 		check_vet
 		;;
+	*,* )
+		set +e
+		checks=$(echo ${RUN} | sed 's/,/ /g')
+		for check in ${checks}; do
+			COMMENT="${COMMENT}${check}: "
+			"${self}" "${check}" "${WORKING_DIR}" "${SEND_COMMENT}" "${GITHUB_TOKEN}" "${FLAGS}" "${IGNORE_DEFER_ERR}" "${MAX_COMPLEXITY}" "${GO_PRIVATE_MOD_USERNAME}" "${GO_PRIVATE_MOD_PASSWORD}" "${GO_PRIVATE_MOD_ORG_PATH}"
+			STATUS=$?
+			if [ ${STATUS} -ne 0 ]; then
+				# 0 on all success; last failed value on any failure
+				SUCCESS=${STATUS}
+				COMMENT="${COMMENT}fail\n"
+			else
+				COMMENT="${COMMENT}success!\n"
+			fi
+		done
+		set -e
+		;;
 	* )
-		echo "Invalid command"
+		echo "Invalid command '${RUN}'"
 		exit 1
-
 esac
 
 if [ ${SUCCESS} -ne 0 ]; then
 	echo "Check Failed!!"
-	echo ${COMMENT}
-	if [ "${SEND_COMMNET}" = "true" ]; then
+	echo "${COMMENT}"
+	if [ "${SEND_COMMENT}" = "true" ]; then
 		send_comment
 	fi
 fi
 
 exit ${SUCCESS}
-


### PR DESCRIPTION
## Related issues

Fixes: grandcolline/golang-github-actions#11

## Description

- Only works for checks that support exclusions (`cyclo`, `errcheck`)
- Other checks silently ignore the setting, since they don't support it

There might be some fancy magic we could do with, say, `find -type f -iname '*.go' ...` instead of `./...`, but even that only works for checks that support lists of files rather than just a single package name/path. Or, well, we'd have to do some major refactoring on the checks that don't support file lists. And probably all the checks, at that, since command lines have a length limit, so large projects would break the logic with a full listing of all non-excluded files.

Anyway, this is the best I can do at the moment without addressing the problems above.

Enjoy!

## Checklist
<!-- Before removing WIP label, check all boxes below. -->

- [x] I have left self-review comments to help other reviewers.
- [x] My PR is as small as possible and focused on a single task.
- [x] I have considered and implemented security best practices.
- [x] If tagging multiple reviewers, I have made specific asks.

## Manual testing
<!-- Before requesting reviews, check all boxes below. -->

- [ ] Ensure `cyclo` still works with and without `exclude` set
- [ ] Ensure `errcheck` still works with and without `exclude` set
- [ ] Implement exclude support from the outside - preferably, by generating a file list and leaving out `exclude` paths/packages to begin with, but in a pinch we can `grep -v` the results instead? (This one's a pretty sizeable refactor either way.)